### PR TITLE
Add CLI specific config file

### DIFF
--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -772,12 +772,21 @@ class Environment
 
 	/**
 	 * Loads and returns options from environment-specific
-	 * PHP files (by host name and server IP address)
+	 * PHP files (by cli, host name and server IP address)
 	 *
 	 * @param string $root Root directory to load configs from
 	 */
 	public function options(string $root): array
 	{
+		// load the config for the cli
+		if ($this->cli() === true) {
+			return F::load(
+				file: $root . '/config.cli.php',
+				fallback: [],
+				allowOutput: false
+			);
+		}
+
 		$configHost = [];
 		$configAddr = [];
 


### PR DESCRIPTION
## This PR …
Adds the option to define a CLI specific config file `config.cli.php`. You can already do something like this by using the `ready` callback and define your CLI specific options in there. Probably only for edge cases but when you need CLI specific options I think this would fit in quite nicely with the current system of environment (host name or ip address) specific options.

```php
// config.php
return [
    'ready' => function (App $kirby) {
        $options = [
            //
        ];

        if ($kirby->environment()->cli()) {
            $options = array_merge($options, [
                'option.one' => 1,
                'option.tow' => 2,
            ]);
        }

        return $options;
    }
];

// config.cli.php
return [
    'option.one' => 1,
    'option.tow' => 2,
];
```

Related: https://discord.com/channels/525634039965679616/525641819854471168/1149657559746224188

### Breaking changes
Hopefully none.

## Ready?
- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass

### For review team
- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
